### PR TITLE
atuin: Download the client executable

### DIFF
--- a/pkgs.ini
+++ b/pkgs.ini
@@ -200,9 +200,9 @@ donate = https://github.com/sponsors/atuinsh
 version = https://github.com/atuinsh/atuin
 
 [atuin.linux_x86_64]
-install_bin = atuin-server-x86_64-unknown-linux-musl/atuin-server
-url = https://github.com/atuinsh/atuin/releases/download/v18.12.1/atuin-server-x86_64-unknown-linux-musl.tar.gz
-hash = f3a1f31b0c5a87ad8af702d8890ed44c2e7ac94225cf27361b350dc17472966c
+install_bin = atuin-x86_64-unknown-linux-musl/atuin
+url = https://github.com/atuinsh/atuin/releases/download/v18.12.1/atuin-x86_64-unknown-linux-musl.tar.gz
+hash = 0b25c91ff0619d2cd912f6b74abeb5f3386a28f06aee0a9d524077660ceeaee7
 
 [autocorrect.info]
 version = 2.16.3


### PR DESCRIPTION
The atuin executable used to include both client and server functionality. But, the server functionality has been extracted into a seperate executable, being released in a separate release archive. See https://github.com/atuinsh/atuin/releases/tag/v18.12.0.

Most users probably expect the atuin *client* executable to be the one to download under the atuin key.
Perhaps an atuin-server key would be a good solution to provide the server executable.

This PR only aims to point the atuin key to the client executable release archive instead of the server one.

The download url started pointing to the server release archive in the commit b7cb7e702226c622865c1a103ec8606e1a352deb.